### PR TITLE
Fix crash related to IntegrityError crashes

### DIFF
--- a/src/clearcode/sync.py
+++ b/src/clearcode/sync.py
@@ -236,7 +236,6 @@ def db_saver(content, blob_path, **kwargs):
     if not created:
         if cditem.content != compressed and cditem.last_modified_date < timezone.now():
             cditem.content = compressed
-            cditem.last_modified_date = timezone.now()
             cditem.save()
             if TRACE:
                 print('Updating content for:', blob_path)

--- a/src/clearcode/tests/test_sync.py
+++ b/src/clearcode/tests/test_sync.py
@@ -1,6 +1,22 @@
+# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2020 by nexB, Inc. http://www.nexb.com/ - All rights reserved.
+# Copyright (c) nexB Inc. and others. All rights reserved.
 #
+# ClearCode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/nexB/clearcode-toolkit/ for support and download.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gzip
 import json
 
@@ -21,7 +37,7 @@ class SyncDbsaverTestCase(TestCase):
             content=gzip.compress(json.dumps(self.test_content).encode('utf-8')),
         )
 
-    def test_db_saver_idential_path(self):
+    def test_db_saver_identical_path(self):
         db_saver(content=self.test_content, blob_path=self.test_path)
         self.assertEqual(1, len(CDitem.objects.all()))
 


### PR DESCRIPTION
* Update db_saver() to use get_or_create to avoid race conditions when
  running in multiple processes.
* Add test_sync.py and two test cases

Addresses: #9

Signed-off-by: Steven Esser <sesser@nexb.com>